### PR TITLE
refactor: rename the domain an agnostic name to be reused

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -46,7 +46,9 @@ trait Common
   def scalafixIvyDeps = Agg(ivy"com.github.liancheng::organize-imports:0.6.0")
 }
 
-object domain extends Common
+object domain extends Common {
+  override def artifactName = "github-dependency-graph-domain"
+}
 
 object plugin extends Common with BuildInfo {
 

--- a/domain/src/io/kipp/github/dependency/graph/domain/DependencyNode.scala
+++ b/domain/src/io/kipp/github/dependency/graph/domain/DependencyNode.scala
@@ -1,4 +1,4 @@
-package io.kipp.mill.github.dependency.graph.domain
+package io.kipp.github.dependency.graph.domain
 
 /** Represents a single dependency.
   *

--- a/domain/src/io/kipp/github/dependency/graph/domain/DependencySnapshot.scala
+++ b/domain/src/io/kipp/github/dependency/graph/domain/DependencySnapshot.scala
@@ -1,4 +1,4 @@
-package io.kipp.mill.github.dependency.graph.domain
+package io.kipp.github.dependency.graph.domain
 
 /** Dependency submission snapshot for GitHub.
   * Modeled after the info found in:

--- a/domain/src/io/kipp/github/dependency/graph/domain/Detector.scala
+++ b/domain/src/io/kipp/github/dependency/graph/domain/Detector.scala
@@ -1,4 +1,4 @@
-package io.kipp.mill.github.dependency.graph.domain
+package io.kipp.github.dependency.graph.domain
 
 /** Detector is the representation of the tool used to gather the dependency
   * snapshot information.

--- a/domain/src/io/kipp/github/dependency/graph/domain/FileInfo.scala
+++ b/domain/src/io/kipp/github/dependency/graph/domain/FileInfo.scala
@@ -1,4 +1,4 @@
-package io.kipp.mill.github.dependency.graph.domain
+package io.kipp.github.dependency.graph.domain
 
 /** Representing the infomation for the manifest file.
   *

--- a/domain/src/io/kipp/github/dependency/graph/domain/Job.scala
+++ b/domain/src/io/kipp/github/dependency/graph/domain/Job.scala
@@ -1,4 +1,4 @@
-package io.kipp.mill.github.dependency.graph.domain
+package io.kipp.github.dependency.graph.domain
 
 /** Job that is being submitted by the dependency snapshot
   *

--- a/domain/src/io/kipp/github/dependency/graph/domain/Manifest.scala
+++ b/domain/src/io/kipp/github/dependency/graph/domain/Manifest.scala
@@ -1,4 +1,4 @@
-package io.kipp.mill.github.dependency.graph.domain
+package io.kipp.github.dependency.graph.domain
 
 /** User-defined metadata to store domain-specific information limited to 8
   *  keys with scalar values.

--- a/plugin/src/io/kipp/mill/github/dependency/graph/Github.scala
+++ b/plugin/src/io/kipp/mill/github/dependency/graph/Github.scala
@@ -1,9 +1,9 @@
 package io.kipp.mill.github.dependency.graph
 
-import io.kipp.mill.github.dependency.graph.domain.DependencySnapshot
-import io.kipp.mill.github.dependency.graph.domain.Detector
-import io.kipp.mill.github.dependency.graph.domain.Job
-import io.kipp.mill.github.dependency.graph.domain.Manifest
+import io.kipp.github.dependency.graph.domain.DependencySnapshot
+import io.kipp.github.dependency.graph.domain.Detector
+import io.kipp.github.dependency.graph.domain.Job
+import io.kipp.github.dependency.graph.domain.Manifest
 
 import java.net.URL
 import java.time.Instant

--- a/plugin/src/io/kipp/mill/github/dependency/graph/ModuleTrees.scala
+++ b/plugin/src/io/kipp/mill/github/dependency/graph/ModuleTrees.scala
@@ -1,7 +1,7 @@
 package io.kipp.mill.github.dependency.graph
 
 import coursier.graph.DependencyTree
-import io.kipp.mill.github.dependency.graph.domain._
+import io.kipp.github.dependency.graph.domain._
 import mill.scalalib.JavaModule
 
 import scala.collection.mutable

--- a/plugin/src/io/kipp/mill/github/dependency/graph/Writers.scala
+++ b/plugin/src/io/kipp/mill/github/dependency/graph/Writers.scala
@@ -1,8 +1,9 @@
 package io.kipp.mill.github.dependency.graph
 
-import io.kipp.mill.github.dependency.graph.domain.DependencyRelationship
-import io.kipp.mill.github.dependency.graph.domain.DependencyScope
-import io.kipp.mill.github.dependency.graph.domain.DependencySnapshot
+import io.kipp.github.dependency.graph.domain.DependencyRelationship
+import io.kipp.github.dependency.graph.domain.DependencyScope
+import io.kipp.github.dependency.graph.domain.DependencySnapshot
+import io.kipp.github.dependency.graph.domain.Manifest
 import ujson.Obj
 import upickle.default.Writer
 
@@ -41,10 +42,10 @@ object Writers {
     *  handler and a couple other things. It ends up being just as short to
     *  manually do all this, and then we avoid having to use ujson.Null as well.
     */
-  implicit val manifestWriter: Writer[domain.Manifest] =
+  implicit val manifestWriter: Writer[Manifest] =
     upickle.default.writer[ujson.Obj].comap(manifestToJson)
 
-  private def manifestToJson(manifest: domain.Manifest): Obj = {
+  private def manifestToJson(manifest: Manifest): Obj = {
     val base = ujson.Obj(
       "name" -> manifest.name,
       "metadata" -> manifest.metadata.toJsonValue,


### PR DESCRIPTION
This will allow for other tools that want to do something similar in
the Scala ecosystem to just re-use domain.
