### PR TITLE
refactor: clean up how we mark direct at the root level

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,5 +1,6 @@
 rules = [
   DisableSyntax
+  ExplicitResultTypes
   LeakingImplicitClassVal
   NoAutoTupling
   NoValInForComprehension

--- a/build.sc
+++ b/build.sc
@@ -3,6 +3,7 @@ import scalalib._
 import scalafmt._
 import publish._
 import mill.scalalib.publish._
+import mill.scalalib.api.ZincWorkerUtil
 import $ivy.`com.goyeau::mill-scalafix::0.2.8`
 import com.goyeau.mill.scalafix.ScalafixModule
 import $ivy.`com.lihaoyi::mill-contrib-buildinfo:$MILL_VERSION`
@@ -15,6 +16,7 @@ import de.tobiasroeser.mill.vcs.version.VcsVersion
 
 // TODO Should probably drop this to 0.10.0, but when I did a bunch of stuff breaks
 val millVersion = "0.10.3"
+val scala213 = "2.13.8"
 val artifactBase = "mill-github-dependency-graph"
 
 def millBinaryVersion(millVersion: String) = scalaNativeBinaryVersion(
@@ -40,11 +42,13 @@ trait Common
       Seq(Developer("ckipp01", "Chris Kipp", "https://www.chris-kipp.io"))
   )
 
-  def scalaVersion = "2.13.8"
+  def scalaVersion = scala213
 
   def scalacOptions = Seq("-Ywarn-unused", "-deprecation")
 
   def scalafixIvyDeps = Agg(ivy"com.github.liancheng::organize-imports:0.6.0")
+
+  def scalafixScalaBinaryVersion = ZincWorkerUtil.scalaBinaryVersion(scala213)
 }
 
 object domain extends Common {
@@ -86,8 +90,10 @@ object itest extends MillIntegrationTestModule {
     T {
       Seq(
         PathRef(testBase / "minimal") -> Seq(
-          TestInvocation.Targets(Seq("checkManifest"), noServer = true),
           TestInvocation.Targets(Seq("checkManifest"), noServer = true)
+        ),
+        PathRef(testBase / "directRelationship") -> Seq(
+          TestInvocation.Targets(Seq("verify"), noServer = true)
         )
       )
     }

--- a/domain/src/io/kipp/github/dependency/graph/domain/DependencyNode.scala
+++ b/domain/src/io/kipp/github/dependency/graph/domain/DependencyNode.scala
@@ -19,7 +19,17 @@ final case class DependencyNode(
     relationship: Option[DependencyRelationship],
     scope: Option[DependencyScope],
     dependencies: Seq[String]
-)
+) {
+
+  /** Returns true if both the relationship exists and is direct
+    */
+  def isDirectDependency = relationship match {
+    case None                                  => false
+    case Some(DependencyRelationship.indirect) => false
+    case Some(DependencyRelationship.direct)   => true
+  }
+
+}
 
 /** A notation of whether a dependency is requested directly
   * by this manifest, or is a dependency of another dependency.

--- a/itest/src/directRelationship/build.sc
+++ b/itest/src/directRelationship/build.sc
@@ -1,0 +1,30 @@
+import mill._, scalalib._
+import $exec.plugins
+import io.kipp.mill.github.dependency.graph.Graph
+import mill.eval.Evaluator
+import $ivy.`org.scalameta::munit:0.7.29`
+import munit.Assertions._
+
+object minimal extends ScalaModule {
+  def scalaVersion = "3.1.3"
+
+  def ivyDeps = Agg(
+    ivy"com.lihaoyi::pprint:0.7.3",
+    ivy"com.lihaoyi::fansi:0.3.1"
+  )
+}
+
+def verify(ev: Evaluator) = T.command {
+  val manifestMapping = Graph.generate(ev)()
+  assert(manifestMapping.size == 1)
+
+  // We want to ensure that fansi here is correctly getting marked as direct
+  // since it will appear as a transitive of pprint being marked as indirect
+  // first, but then should be updated when fansi is processed as a root nood
+  // to direct.
+  val fansiIsDirect = manifestMapping.head._2.resolved
+    .get("com.lihaoyi:fansi_3:0.3.1")
+    .exists(_.isDirectDependency)
+
+  assert(fansiIsDirect)
+}

--- a/itest/src/minimal/build.sc
+++ b/itest/src/minimal/build.sc
@@ -3,7 +3,8 @@ import $exec.plugins
 import io.kipp.mill.github.dependency.graph.Graph
 import io.kipp.mill.github.dependency.graph.Writers._
 import mill.eval.Evaluator
-import $ivy.`org.scalameta::munit:0.7.29`, munit.Assertions._
+import $ivy.`org.scalameta::munit:0.7.29`
+import munit.Assertions._
 
 object minimal extends ScalaModule {
   def scalaVersion = "3.1.3"

--- a/plugin/src/io/kipp/mill/github/dependency/graph/Graph.scala
+++ b/plugin/src/io/kipp/mill/github/dependency/graph/Graph.scala
@@ -1,6 +1,9 @@
 package io.kipp.mill.github.dependency.graph
 
+import io.kipp.github.dependency.graph.domain
 import mill._
+import mill.define.Command
+import mill.define.Discover
 import mill.define.ExternalModule
 import mill.eval.Evaluator
 import mill.main.EvaluatorScopt
@@ -9,23 +12,25 @@ object Graph extends ExternalModule { outer =>
 
   import Writers._
 
-  def submit(ev: Evaluator) = T.command {
+  def submit(ev: Evaluator): Command[Unit] = T.command {
     val manifests = generate(ev)()
     val snapshot = Github.snapshot(manifests)
     Github.submit(snapshot)
   }
 
-  def generate(ev: Evaluator) = T.command {
-    val modules = Resolver.computeModules(ev)
-    val moduleTrees = Resolver.resolveModuleTrees(ev, modules)
-    val manifests =
-      moduleTrees.map(mt => (mt.module.toString(), mt.toManifest())).toMap
-    manifests
-  }
+  def generate(ev: Evaluator): Command[Map[String, domain.Manifest]] =
+    T.command {
+      val modules = Resolver.computeModules(ev)
+      val moduleTrees = Resolver.resolveModuleTrees(ev, modules)
+      val manifests: Map[String, domain.Manifest] =
+        moduleTrees.map(mt => (mt.module.toString(), mt.toManifest())).toMap
+
+      manifests
+    }
 
   implicit def millScoptEvaluatorReads[T]: EvaluatorScopt[T] =
     new mill.main.EvaluatorScopt[T]()
 
-  lazy val millDiscover = mill.define.Discover[this.type]
+  lazy val millDiscover: Discover[this.type] = mill.define.Discover[this.type]
 
 }


### PR DESCRIPTION
This just improves the way we mark a direct dependency if it's at the
top level and has already been seen before. It ensure we don't update a
key with the same exact node again hopefully saving us a bit. I also add
in a test here under directRelationship that explicitly tests for this.
