### PR TITLE
fix: ensure evicted deps are not included

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -94,6 +94,9 @@ object itest extends MillIntegrationTestModule {
         ),
         PathRef(testBase / "directRelationship") -> Seq(
           TestInvocation.Targets(Seq("verify"), noServer = true)
+        ),
+        PathRef(testBase / "eviction") -> Seq(
+          TestInvocation.Targets(Seq("verify"), noServer = true)
         )
       )
     }

--- a/itest/src/eviction/build.sc
+++ b/itest/src/eviction/build.sc
@@ -10,7 +10,7 @@ object minimal extends ScalaModule {
 
   def ivyDeps = Agg(
     ivy"com.lihaoyi::pprint:0.7.3",
-    ivy"com.lihaoyi::fansi:0.3.1"
+    ivy"com.lihaoyi::fansi:0.3.0"
   )
 }
 
@@ -18,11 +18,11 @@ def verify(ev: Evaluator) = T.command {
   val manifestMapping = Graph.generate(ev)()
   assert(manifestMapping.size == 1)
 
-  // We want to ensure that fansi here is correctly getting marked as direct
-  // since it will appear as a transitive of pprint being marked as indirect
-  // first, but then should be updated when fansi is processed as a root node
-  // to direct. Also note that it stays as direct because it's not getting
-  // evicted. Check out the evicted test for more info.
+  // Very similiar to the directRelationship test but in this case fansi 0.3.0
+  // _shouldn't_ be marked as direct in the end result. This is because it will
+  // end up being evicted by 0.3.1 in pprint, so we don't need to even include
+  // it. However, it should end up being replaced by 0.3.1 and still marked as
+  // a direct.
   val fansiIsDirect = manifestMapping.head._2.resolved
     .get("com.lihaoyi:fansi_3:0.3.1")
     .exists(_.isDirectDependency)

--- a/itest/src/minimal/manifests.json
+++ b/itest/src/minimal/manifests.json
@@ -17,16 +17,6 @@
         "relationship": "direct",
         "package_url": "pkg:maven/com.lihaoyi/pprint_3@0.7.3"
       },
-      "org.scala-lang:scala3-library_3:3.0.0": {
-        "metadata": {
-          
-        },
-        "dependencies": [
-          "org.scala-lang:scala-library:2.13.8"
-        ],
-        "relationship": "indirect",
-        "package_url": "pkg:maven/org.scala-lang/scala3-library_3@3.0.0"
-      },
       "com.lihaoyi:fansi_3:0.3.1": {
         "metadata": {
           
@@ -67,16 +57,6 @@
         ],
         "relationship": "direct",
         "package_url": "pkg:maven/org.scala-lang/scala3-library_3@3.1.3"
-      },
-      "org.scala-lang:scala3-library_3:3.0.2": {
-        "metadata": {
-          
-        },
-        "dependencies": [
-          "org.scala-lang:scala-library:2.13.8"
-        ],
-        "relationship": "indirect",
-        "package_url": "pkg:maven/org.scala-lang/scala3-library_3@3.0.2"
       }
     },
     "file": {
@@ -100,16 +80,6 @@
         ],
         "relationship": "direct",
         "package_url": "pkg:maven/com.lihaoyi/pprint_3@0.7.3"
-      },
-      "org.scala-lang:scala3-library_3:3.0.0": {
-        "metadata": {
-          
-        },
-        "dependencies": [
-          "org.scala-lang:scala-library:2.13.8"
-        ],
-        "relationship": "indirect",
-        "package_url": "pkg:maven/org.scala-lang/scala3-library_3@3.0.0"
       },
       "org.scalameta:junit-interface:0.7.29": {
         "metadata": {
@@ -142,6 +112,28 @@
         ],
         "relationship": "indirect",
         "package_url": "pkg:maven/org.hamcrest/hamcrest-core@1.3"
+      },
+      "org.scalameta:munit_3:0.7.29": {
+        "metadata": {
+          
+        },
+        "dependencies": [
+          "junit:junit:4.13.1",
+          "org.scala-lang:scala3-library_3:3.0.1",
+          "org.scalameta:junit-interface:0.7.29"
+        ],
+        "relationship": "direct",
+        "package_url": "pkg:maven/org.scalameta/munit_3@0.7.29"
+      },
+      "org.scala-sbt:test-interface:1.0": {
+        "metadata": {
+          
+        },
+        "dependencies": [
+          
+        ],
+        "relationship": "indirect",
+        "package_url": "pkg:maven/org.scala-sbt/test-interface@1.0"
       },
       "com.lihaoyi:sourcecode_3:0.2.8": {
         "metadata": {
@@ -182,58 +174,6 @@
         ],
         "relationship": "indirect",
         "package_url": "pkg:maven/junit/junit@4.13.2"
-      },
-      "org.scala-lang:scala3-library_3:3.0.2": {
-        "metadata": {
-          
-        },
-        "dependencies": [
-          "org.scala-lang:scala-library:2.13.8"
-        ],
-        "relationship": "indirect",
-        "package_url": "pkg:maven/org.scala-lang/scala3-library_3@3.0.2"
-      },
-      "org.scalameta:munit_3:0.7.29": {
-        "metadata": {
-          
-        },
-        "dependencies": [
-          "junit:junit:4.13.1",
-          "org.scala-lang:scala3-library_3:3.0.1",
-          "org.scalameta:junit-interface:0.7.29"
-        ],
-        "relationship": "direct",
-        "package_url": "pkg:maven/org.scalameta/munit_3@0.7.29"
-      },
-      "org.scala-lang:scala3-library_3:3.0.1": {
-        "metadata": {
-          
-        },
-        "dependencies": [
-          "org.scala-lang:scala-library:2.13.8"
-        ],
-        "relationship": "indirect",
-        "package_url": "pkg:maven/org.scala-lang/scala3-library_3@3.0.1"
-      },
-      "junit:junit:4.13.1": {
-        "metadata": {
-          
-        },
-        "dependencies": [
-          "org.hamcrest:hamcrest-core:1.3"
-        ],
-        "relationship": "indirect",
-        "package_url": "pkg:maven/junit/junit@4.13.1"
-      },
-      "org.scala-sbt:test-interface:1.0": {
-        "metadata": {
-          
-        },
-        "dependencies": [
-          
-        ],
-        "relationship": "indirect",
-        "package_url": "pkg:maven/org.scala-sbt/test-interface@1.0"
       }
     },
     "file": {

--- a/plugin/src/io/kipp/mill/github/dependency/graph/ModuleTrees.scala
+++ b/plugin/src/io/kipp/mill/github/dependency/graph/ModuleTrees.scala
@@ -28,10 +28,12 @@ final case class ModuleTrees(
   def toFlattenedNodes(): Map[String, DependencyNode] = {
 
     val allDependencies = mutable.Map[String, DependencyNode]()
+    val reconciledDirects = mutable.Set[String]()
 
     def toNode(tree: DependencyTree, root: Boolean): Unit = {
       val dep = tree.dependency
-      val name = s"${dep.module.orgName}:${dep.version}"
+      val moduleOrgName = dep.module.orgName
+      val name = s"${moduleOrgName}:${dep.version}"
 
       def putTogether: DependencyNode = {
         // TODO consider classifiers
@@ -55,28 +57,52 @@ final case class ModuleTrees(
       def verifyRelationship(node: DependencyNode) =
         (root && node.isDirectDependency) || (!root && !node.isDirectDependency)
 
-      allDependencies.get(name) match {
-        // If the node is found and the relationship is correct just do nothing
-        case Some(node) if verifyRelationship(node) => ()
-        // If the node is found and the relationship is incorrect, but it's a
-        // root node, then make sure to mark it as direct
-        case Some(node) if root =>
-          val updated =
-            node.copy(relationship = Some(DependencyRelationship.direct))
-          allDependencies += ((name, updated))
-        // Should never really happen, but it it does do nothing
-        case Some(_) => ()
-        // Unseen dependency, create a node for it
-        case None =>
-          val node = putTogether
-          allDependencies += ((name, node))
+      val getsEvicted = dep.version != tree.retainedVersion
+      // So the idea here is that if the retained version doesn't match the dep
+      // version, we know that the dep ends up getting evicted, so we don't
+      // actually need it as an entry since it won't end up on the classpath.
+      // However if it's a root node, we need to ensure we later go back and
+      // mark it as direct. We don't do it while iterating because we may have
+      // already seen the dep that evicted it. See the evicted test for an
+      // example.
+      if (getsEvicted && root) {
+        reconciledDirects += s"${moduleOrgName}:${tree.retainedVersion}"
+      } else if (getsEvicted) {
+        // If we know it's evicted here, but we're not at the root level, then
+        // it doesn't matter because it's still not a direct dep.
+        ()
+      } else {
+        allDependencies.get(name) match {
+          // If the node is found and the relationship is correct just do nothing
+          case Some(node) if verifyRelationship(node) => ()
+          // If the node is found and the relationship is incorrect, but it's a
+          // root node, then make sure to mark it as direct
+          case Some(node) if root =>
+            val updated =
+              node.copy(relationship = Some(DependencyRelationship.direct))
+            allDependencies += ((name, updated))
+          // Should never really happen, but it it does do nothing
+          case Some(_) => ()
+          // Unseen dependency, create a node for it
+          case None =>
+            val node = putTogether
+            allDependencies += ((name, node))
+        }
       }
 
       tree.children.foreach(toNode(_, root = false))
     }
 
     dependencyTrees.foreach(toNode(_, root = true))
-    allDependencies.toMap
+
+    // Before we return we ensure that we take care of marking any of the root
+    // reconciled versions as direct.
+    allDependencies.toMap.map {
+      case (key, node)
+          if reconciledDirects.contains(key) && !node.isDirectDependency =>
+        (key, node.copy(relationship = Some(DependencyRelationship.direct)))
+      case fineAsIs => identity(fineAsIs)
+    }
   }
 
   def toManifest() = {


### PR DESCRIPTION
This fix ensures that deps that end up being evicted aren't
included in the end result. Here is an example to demonstrate
what I mean. Given the following deps:

```
  def ivyDeps = Agg(
    ivycom.lihaoyi::pprint:0.7.3,
    ivycom.lihaoyi::sourcecode:0.2.7
  )
```

If you look at the dep tree of pprint:

```
❯ cs resolve com.lihaoyi:pprint_3:0.7.3
com.lihaoyi:fansi_3:0.3.1:default
com.lihaoyi:pprint_3:0.7.3:default
com.lihaoyi:sourcecode_3:0.2.8:default
org.scala-lang:scala-library:2.13.6:default
org.scala-lang:scala3-library_3:3.0.2:default
```

Notice the reliance on sourcecode 0.2.8. The means your direct
reliance on 0.2.7 will end up being evicted and you'll really
have 0.2.8 on your classpath. This change ensure that in this
specific situation that 0.2.7 isn't reported and instead 0.2.8
is reported as a direct.
