### PR TITLE
fix: ensure ranges don't end up in manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bsp/
 .metals/
 out/
+manifest.json

--- a/build.sc
+++ b/build.sc
@@ -97,6 +97,9 @@ object itest extends MillIntegrationTestModule {
         ),
         PathRef(testBase / "eviction") -> Seq(
           TestInvocation.Targets(Seq("verify"), noServer = true)
+        ),
+        PathRef(testBase / "range") -> Seq(
+          TestInvocation.Targets(Seq("verify"), noServer = true)
         )
       )
     }

--- a/itest/src/minimal/manifests.json
+++ b/itest/src/minimal/manifests.json
@@ -12,7 +12,7 @@
         "dependencies": [
           "com.lihaoyi:fansi_3:0.3.1",
           "com.lihaoyi:sourcecode_3:0.2.8",
-          "org.scala-lang:scala3-library_3:3.0.2"
+          "org.scala-lang:scala3-library_3:3.1.3"
         ],
         "relationship": "direct",
         "package_url": "pkg:maven/com.lihaoyi/pprint_3@0.7.3"
@@ -23,7 +23,7 @@
         },
         "dependencies": [
           "com.lihaoyi:sourcecode_3:0.2.8",
-          "org.scala-lang:scala3-library_3:3.0.2"
+          "org.scala-lang:scala3-library_3:3.1.3"
         ],
         "relationship": "indirect",
         "package_url": "pkg:maven/com.lihaoyi/fansi_3@0.3.1"
@@ -33,7 +33,7 @@
           
         },
         "dependencies": [
-          "org.scala-lang:scala3-library_3:3.0.0"
+          "org.scala-lang:scala3-library_3:3.1.3"
         ],
         "relationship": "indirect",
         "package_url": "pkg:maven/com.lihaoyi/sourcecode_3@0.2.8"
@@ -76,7 +76,7 @@
         "dependencies": [
           "com.lihaoyi:fansi_3:0.3.1",
           "com.lihaoyi:sourcecode_3:0.2.8",
-          "org.scala-lang:scala3-library_3:3.0.2"
+          "org.scala-lang:scala3-library_3:3.1.3"
         ],
         "relationship": "direct",
         "package_url": "pkg:maven/com.lihaoyi/pprint_3@0.7.3"
@@ -98,7 +98,7 @@
         },
         "dependencies": [
           "com.lihaoyi:sourcecode_3:0.2.8",
-          "org.scala-lang:scala3-library_3:3.0.2"
+          "org.scala-lang:scala3-library_3:3.1.3"
         ],
         "relationship": "indirect",
         "package_url": "pkg:maven/com.lihaoyi/fansi_3@0.3.1"
@@ -118,8 +118,8 @@
           
         },
         "dependencies": [
-          "junit:junit:4.13.1",
-          "org.scala-lang:scala3-library_3:3.0.1",
+          "junit:junit:4.13.2",
+          "org.scala-lang:scala3-library_3:3.1.3",
           "org.scalameta:junit-interface:0.7.29"
         ],
         "relationship": "direct",
@@ -140,7 +140,7 @@
           
         },
         "dependencies": [
-          "org.scala-lang:scala3-library_3:3.0.0"
+          "org.scala-lang:scala3-library_3:3.1.3"
         ],
         "relationship": "indirect",
         "package_url": "pkg:maven/com.lihaoyi/sourcecode_3@0.2.8"

--- a/itest/src/range/build.sc
+++ b/itest/src/range/build.sc
@@ -1,0 +1,32 @@
+import mill._, scalalib._
+import $exec.plugins
+import io.kipp.mill.github.dependency.graph.Graph
+import mill.eval.Evaluator
+import $ivy.`org.scalameta::munit:0.7.29`
+import munit.Assertions._
+
+object minimal extends ScalaModule {
+  def scalaVersion = "3.1.3"
+
+  def ivyDeps = Agg(
+    ivy"org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.12.0"
+  )
+}
+
+def verify(ev: Evaluator) = T.command {
+  val manifestMapping = Graph.generate(ev)()
+  assert(manifestMapping.size == 1)
+
+  // We want to ensure that the transitive dependency of the above, which has a
+  // range dependency doesn't end up in the actualy manifest as a range, but
+  // the reconciled version. So we want to ensure `2.8.9` and not
+  // `[2.8.6,2.0)`.
+  val expected = Set(
+    "org.scala-lang:scala-library:2.13.8",
+    "org.scala-lang:scala3-library_3:3.1.3",
+    "org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.12.0",
+    "com.google.code.gson:gson:2.8.9"
+  )
+
+  assertEquals(manifestMapping.head._2.resolved.keys, expected)
+}


### PR DESCRIPTION
There was (and still is) a bit of confusion on the difference between
`retainedVersion` and `reconciledVersion` in couriser. It used to be
that I was using the `retainedVersion`, but that still ends up being a
range, so I switch to `reconciledVersion`. This change also simplifies a
bit of the logic by ensuring the the dependencies listed under
`resolved` are indeed the dependencies that end up being resolved in the
context of your project, not just that single app. I'll explain this
further in the docs.
