### PR TITLE
fix: ensure invalid PURLs are not included

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -62,9 +62,13 @@ object plugin extends Common with BuildInfo {
 
   override def moduleDeps = Seq(domain)
   override def compileIvyDeps = super.compileIvyDeps() ++ Agg(
-    ivy"com.lihaoyi::mill-scalalib:$millVersion",
+    ivy"com.lihaoyi::mill-scalalib:$millVersion"
+  )
+
+  override def ivyDeps = super.ivyDeps() ++ Agg(
     ivy"com.lihaoyi::upickle:2.0.0",
-    ivy"com.lihaoyi::requests:0.7.1"
+    ivy"com.lihaoyi::requests:0.7.1",
+    ivy"com.github.package-url:packageurl-java:1.4.1"
   )
 
   override def buildInfoMembers = Map(
@@ -99,6 +103,9 @@ object itest extends MillIntegrationTestModule {
           TestInvocation.Targets(Seq("verify"), noServer = true)
         ),
         PathRef(testBase / "range") -> Seq(
+          TestInvocation.Targets(Seq("verify"), noServer = true)
+        ),
+        PathRef(testBase / "reconciledRange") -> Seq(
           TestInvocation.Targets(Seq("verify"), noServer = true)
         )
       )

--- a/itest/src/reconciledRange/build.sc
+++ b/itest/src/reconciledRange/build.sc
@@ -1,0 +1,67 @@
+import mill._, scalalib._
+import $exec.plugins
+import io.kipp.mill.github.dependency.graph.Graph
+import mill.eval.Evaluator
+import $ivy.`org.scalameta::munit:0.7.29`
+import munit.Assertions._
+
+object minimalDep extends ScalaModule {
+  def scalaVersion = "2.13.8"
+
+  def ivyDeps = Agg(
+    ivy"com.fasterxml.jackson.core:jackson-core:2.13.3"
+  )
+}
+
+object minimal extends ScalaModule {
+  def moduleDeps = Seq(`minimalDep`)
+
+  def scalaVersion = "2.13.8"
+
+  def ivyDeps = Agg(
+    ivy"org.jongo:jongo:1.5.0"
+  )
+}
+
+def verify(ev: Evaluator) = T.command {
+  val manifestMapping = Graph.generate(ev)()
+  assert(manifestMapping.size == 2)
+
+  // OK, this is a super weird one. Jongo here has a range dep which is fine, and when
+  // it's resolved by itself, it correctly gets 2.12.3 like you can see below:
+  //
+  // ❯ cs resolve org.jongo:jongo:1.5.0
+  // com.fasterxml.jackson.core:jackson-annotations:2.12.3:default
+  // com.fasterxml.jackson.core:jackson-core:2.12.3:default
+  // com.fasterxml.jackson.core:jackson-databind:2.12.3:default
+  // de.undercouch:bson4jackson:2.12.0:default
+  // org.jongo:jongo:1.5.0:default
+  //
+  // The issue enteres with a setup like the above. For some reason coursier
+  // will actually retain the range as the reconciledVersion in the
+  // DependencyTree when it should be the actual reconciled versions.
+  //
+  // dep version: [2.7.0,2.12.3]
+  // retained version: [2.7.0,2.12.3]
+  // reconciled version: [2.7.0,2.12.3]
+  //
+  // Since I believe this to be a bug in coursier for now we'll just throw them
+  // out to ensure we're not creating invalid PURLs.
+  val expected = Set(
+    "org.scala-lang:scala-library:2.13.8",
+    "com.fasterxml.jackson.core:jackson-core:2.13.3",
+    // NOTICE that com.fasterxml.jackson.core:jackson-core:[2.7.0,2.12.3] is not here
+    "com.fasterxml.jackson.core:jackson-core:2.12.3",
+    "com.fasterxml.jackson.core:jackson-databind:2.12.3",
+    "com.fasterxml.jackson.core:jackson-annotations:2.12.3",
+    "org.jongo:jongo:1.5.0",
+    "de.undercouch:bson4jackson:2.12.0"
+  )
+
+  val results = manifestMapping.foldLeft[Set[String]](Set.empty) {
+    case (set, mapping) =>
+      set ++ mapping._2.resolved.keySet
+  }
+
+  assertEquals(results, expected)
+}


### PR DESCRIPTION
This adds in the package-url-java dep to help ensure that we don't have
invalid written PURLs, however that will still allow for a range, which
we don't want. So we add in some logic that if a range is detected in
the `reconciledVersion`, we throw it out and issue an error. This should
be extremely rare, but this will at least allow the graph to submit and
show.

refs: #40
