### PR TITLE
fix: guard against cyclical dependencies which can cause a stackoverflow

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -109,6 +109,9 @@ object itest extends MillIntegrationTestModule {
         ),
         PathRef(testBase / "reconciledRange") -> Seq(
           TestInvocation.Targets(Seq("verify"), noServer = true)
+        ),
+        PathRef(testBase / "cyclical") -> Seq(
+          TestInvocation.Targets(Seq("checkManifest"), noServer = true)
         )
       )
     }

--- a/itest/src/cyclical/build.sc
+++ b/itest/src/cyclical/build.sc
@@ -1,0 +1,33 @@
+import mill._, scalalib._
+import $exec.plugins
+import io.kipp.mill.github.dependency.graph.Graph
+import io.kipp.mill.github.dependency.graph.Writers._
+import mill.eval.Evaluator
+import $ivy.`org.scalameta::munit:0.7.29`
+import munit.Assertions._
+
+object overflow extends ScalaModule {
+
+  def scalaVersion = "2.13.10"
+
+  // See https://github.com/ckipp01/mill-github-dependency-graph/issues/77 for the context
+  // of this test. The main issue is that when you look at the children of this dep in coursier
+  // it is cyclical and will just continually list itself. So we have to add in some extra guards
+  // against this.
+  override def ivyDeps: T[Agg[Dep]] = Agg(
+    ivy"io.netty:netty-tcnative-boringssl-static:2.0.54.Final"
+  )
+
+}
+
+def checkManifest(ev: Evaluator) = T.command {
+  val expected = ujson.read(os.read(os.pwd / "manifests.json"))
+
+  val manifestMapping = Graph.generate(ev)()
+
+  // Lil hacky but if we compare the strings they won't match, so we read that
+  // back up into a ujson.Value so we can compare those two
+  val result = ujson.read(upickle.default.write(manifestMapping))
+
+  assertEquals(result, expected)
+}

--- a/itest/src/cyclical/manifests.json
+++ b/itest/src/cyclical/manifests.json
@@ -1,0 +1,51 @@
+{
+  "overflow": {
+    "name": "overflow",
+    "metadata": {
+      
+    },
+    "resolved": {
+      "io.netty:netty-tcnative-classes:2.0.54.Final": {
+        "metadata": {
+          
+        },
+        "dependencies": [
+          
+        ],
+        "relationship": "indirect",
+        "package_url": "pkg:maven/io.netty/netty-tcnative-classes@2.0.54.Final"
+      },
+      "org.scala-lang:scala-library:2.13.10": {
+        "metadata": {
+          
+        },
+        "dependencies": [
+          
+        ],
+        "relationship": "direct",
+        "package_url": "pkg:maven/org.scala-lang/scala-library@2.13.10"
+      },
+      "io.netty:netty-tcnative-boringssl-static:2.0.54.Final": {
+        "metadata": {
+          
+        },
+        "dependencies": [
+          "io.netty:netty-tcnative-boringssl-static:2.0.54.Final",
+          "io.netty:netty-tcnative-boringssl-static:2.0.54.Final",
+          "io.netty:netty-tcnative-boringssl-static:2.0.54.Final",
+          "io.netty:netty-tcnative-boringssl-static:2.0.54.Final",
+          "io.netty:netty-tcnative-boringssl-static:2.0.54.Final",
+          "io.netty:netty-tcnative-boringssl-static:2.0.54.Final",
+          "io.netty:netty-tcnative-boringssl-static:2.0.54.Final",
+          "io.netty:netty-tcnative-boringssl-static:2.0.54.Final",
+          "io.netty:netty-tcnative-classes:2.0.54.Final"
+        ],
+        "relationship": "direct",
+        "package_url": "pkg:maven/io.netty/netty-tcnative-boringssl-static@2.0.54.Final"
+      }
+    },
+    "file": {
+      "source_location": "build.sc"
+    }
+  }
+}


### PR DESCRIPTION
So I don't fully love this solution as it adds to the even more hacks I
need for coursier oddness, but there are situations using deps like you
see in the test here that when you look at the children of the
dependency, it lists itself. Some of them are expected due to different
classifiers, but even one with a classifier will list itself as well as
a dep. This leads to really odd cyclical dependency behavior when you
try to traverse the tree. So to guard against this we do a few
different things:

- we do a better job of not processing children that were already
  processed before
- we filter self out when self is listed as a child
- we also cache lookup to ensure we aren't always going from tree->name
  multiple times as we're iterating.

This will fix
https://github.com/ckipp01/mill-github-dependency-graph/issues/77, but I
think this should probably be addressed upstream. I've created
https://github.com/coursier/coursier/issues/2683 to track this.

Just a NOTE, this still doesn't fix the issues with not having
classifiers shown, but I'll do a follow-up to add those in since it's
not a huge change.

Fixes: https://github.com/ckipp01/mill-github-dependency-graph/issues/77
